### PR TITLE
add PR template and Codeowners

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add owners for all files. No need to only require some people for certain file types, since it it just 1 person
+* @adrianlacour

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary of change
+
+## Demo
+
+## Testing
+
+## Notes
+
+## Checklist
+- [ ] Created unit test
+- [ ] Documentation of new feature is added


### PR DESCRIPTION
Adds PR template, to ensure that the proper info is filled out

Adds codeowners doc, to ensure only those people mentioned can make commits. 